### PR TITLE
Add id attribute to widget forms' tab and fieldset.

### DIFF
--- a/forms/widgets/blog_filters.xml
+++ b/forms/widgets/blog_filters.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form i18nBaseUri="widgets.blog_filters:">
-    <tab>
-        <fieldset>
+    <tab id="main">
+        <fieldset id="main">
             <field name="blog"                     sortorder="5"  control="objectpicker" object="blog"  required="true"   />
             <field name="include_author_filter"    sortorder="10" control="yesnoswitch"  default="true"                   />
             <field name="author_filter_title"      sortorder="20" control="textinput"    default="Authors" maxlength="16" />
             <field name="author_filter_expanded"   sortorder="30" control="yesnoswitch"  default="false"                  />
-            
+
             <field name="include_archive_filter"   sortorder="40" control="yesnoswitch"  default="true"                   />
             <field name="archive_filter_title"     sortorder="50" control="textinput"    default="Archive" maxlength="16" />
             <field name="archive_filter_expanded"  sortorder="60" control="yesnoswitch"  default="false"                  />

--- a/forms/widgets/blog_post_list.xml
+++ b/forms/widgets/blog_post_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form i18nBaseUri="widgets.blog_post_list:">
-	<tab>
-		<fieldset>
+	<tab id="main">
+		<fieldset id="main">
             <field name="blog"               control="objectpicker" object="blog" required="true" />
 			<field name="title" />
 			<field name="top_posts_only"     control="yesnoswitch" default="false" />

--- a/forms/widgets/blog_tag_list.xml
+++ b/forms/widgets/blog_tag_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form i18nBaseUri="widgets.blog_tag_list:">
-	<tab>
-		<fieldset>
+	<tab id="main">
+		<fieldset id="main">
             <field name="blog" control="objectpicker" object="blog" required="true" />
 			<field name="title" />
 			<field name="featured" control="yesnoswitch" default="false" />

--- a/forms/widgets/rss_feed.xml
+++ b/forms/widgets/rss_feed.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form i18nBaseUri="widgets.rss_feed:">
-	<tab>
-		<fieldset>
+	<tab id="main">
+		<fieldset id="main">
 			<field name="blog" control="objectpicker" object="blog" required="true" />
 		</fieldset>
 	</tab>


### PR DESCRIPTION
Hi @jjannek, I've added the id attribute to widget forms' tab and fieldset. This is to enable overriding the form in preside project development.